### PR TITLE
Fix client settings not being available server-side

### DIFF
--- a/src/main/java/org/cloudwarp/quickstack/networking/DumpC2SPacket.java
+++ b/src/main/java/org/cloudwarp/quickstack/networking/DumpC2SPacket.java
@@ -6,11 +6,13 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.cloudwarp.quickstack.registry.QuickStackDepositFunctions;
+import org.cloudwarp.quickstack.utils.QSConfig;
 
 public class DumpC2SPacket {
 	public static void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender){
+		var config = QSConfig.readConfig(buf);
 		server.execute(() -> {
-			QuickStackDepositFunctions.findNearbyChests(player, false);
+			QuickStackDepositFunctions.findNearbyChests(player, false, config);
 			return;
 		});
 	}

--- a/src/main/java/org/cloudwarp/quickstack/networking/QuickStackC2SPacket.java
+++ b/src/main/java/org/cloudwarp/quickstack/networking/QuickStackC2SPacket.java
@@ -6,9 +6,11 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.cloudwarp.quickstack.registry.QuickStackDepositFunctions;
+import org.cloudwarp.quickstack.utils.QSConfig;
 
 public class QuickStackC2SPacket {
 	public static void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender){
-		server.execute(() -> QuickStackDepositFunctions.findNearbyChests(player, true));
+		var config = QSConfig.readConfig(buf);
+		server.execute(() -> QuickStackDepositFunctions.findNearbyChests(player, true, config));
 	}
 }

--- a/src/main/java/org/cloudwarp/quickstack/registry/QSKeyInputHandler.java
+++ b/src/main/java/org/cloudwarp/quickstack/registry/QSKeyInputHandler.java
@@ -1,5 +1,6 @@
 package org.cloudwarp.quickstack.registry;
 
+import io.netty.buffer.Unpooled;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
@@ -44,7 +45,7 @@ public class QSKeyInputHandler {
 
 				if (InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow().getHandle(), KeyBindingHelper.getBoundKeyOf(quickStackKey).getCode())) {
 					if (! isQuickStackPressed && config.enableQuickStackFeature) {
-						client.execute(() -> ClientPlayNetworking.send(QuickStackMessages.QUICK_STACK_ID, PacketByteBufs.empty()));
+						client.execute(() -> ClientPlayNetworking.send(QuickStackMessages.QUICK_STACK_ID, config.writeConfig()));
 
 						isQuickStackPressed = true;
 					}
@@ -53,7 +54,7 @@ public class QSKeyInputHandler {
 				}
 				if (InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow().getHandle(), KeyBindingHelper.getBoundKeyOf(dumpKey).getCode())) {
 					if (! isDumpPressed && config.enableDumpFeature) {
-						client.execute(() -> ClientPlayNetworking.send(QuickStackMessages.DUMP_ID, PacketByteBufs.empty()));
+						client.execute(() -> ClientPlayNetworking.send(QuickStackMessages.DUMP_ID, config.writeConfig()));
 						isDumpPressed = true;
 					}
 				} else {

--- a/src/main/java/org/cloudwarp/quickstack/registry/QuickStackDepositFunctions.java
+++ b/src/main/java/org/cloudwarp/quickstack/registry/QuickStackDepositFunctions.java
@@ -26,11 +26,10 @@ import java.util.stream.IntStream;
 
 public class QuickStackDepositFunctions {
 	private static Set<Identifier> chestBlocks = new HashSet<>();
-	public static void findNearbyChests (ServerPlayerEntity player, boolean quickStack) {
+	public static void findNearbyChests (ServerPlayerEntity player, boolean quickStack, QSConfig config) {
 		World world = player.getWorld();
 		Inventory playerInventory = player.getInventory();
 		chestBlocks = new HashSet<>();
-		QSConfig config = QuickStack.getConfig();
 		AtomicInteger chestsDepositedInto = new AtomicInteger();
 		AtomicInteger itemsDeposited = new AtomicInteger();
 		BlockPos.iterateOutwards(player.getBlockPos(),config.searchRadius,config.searchRadius,config.searchRadius).forEach(blockPos -> {
@@ -62,7 +61,7 @@ public class QuickStackDepositFunctions {
 					if(quickStack && !hasItem){
 						continue;
 					}
-					ItemStack itemStack2 = transfer(playerInventory, inventory, playerInventory.removeStack(j, itemStack.getCount()), hasItem && quickStack);
+					ItemStack itemStack2 = transfer(playerInventory, inventory, playerInventory.removeStack(j, itemStack.getCount()), hasItem && quickStack, config);
 					//markDirty(world,blockPos,world.getBlockState(blockPos));
 					if (itemStack2.isEmpty()) {
 						inventory.markDirty();
@@ -88,7 +87,7 @@ public class QuickStackDepositFunctions {
 		}
 	}
 
-	public static ItemStack transfer (@Nullable Inventory from, Inventory to, ItemStack stack, boolean hasItem) {
+	public static ItemStack transfer (@Nullable Inventory from, Inventory to, ItemStack stack, boolean hasItem, QSConfig config) {
 		int j = to.size();
 		if(hasItem) {
 			for (int k = 0; k < j && ! stack.isEmpty(); ++ k) {
@@ -96,7 +95,7 @@ public class QuickStackDepositFunctions {
 					stack = transfer(from, to, stack, k);
 				}
 			}
-			if(!QuickStack.getConfig().stopAfterFillingStacks) {
+			if(!config.stopAfterFillingStacks) {
 				for (int k = 0; k < j && ! stack.isEmpty(); ++ k) {
 					stack = transfer(from, to, stack, k);
 				}

--- a/src/main/java/org/cloudwarp/quickstack/utils/QSConfig.java
+++ b/src/main/java/org/cloudwarp/quickstack/utils/QSConfig.java
@@ -1,22 +1,47 @@
 package org.cloudwarp.quickstack.utils;
 
+import io.netty.buffer.Unpooled;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import net.minecraft.network.PacketByteBuf;
 import org.cloudwarp.quickstack.QuickStack;
 
 @Config(name = QuickStack.MOD_ID)
 public class QSConfig implements ConfigData {
 
-		public boolean enableDumpFeature           = true;
-		public boolean enableQuickStackFeature     = true;
-		public boolean ignoreHotbar = true;
-		@ConfigEntry.BoundedDiscrete(min = 0,max = 30)
-		public int     searchRadius                = 5;
-		@ConfigEntry.BoundedDiscrete(min = 0,max = 100)
-		public int     maxContainersPerDump        = 50;
-		public boolean enableQuickStackOutputInfo  = true;
-		public boolean stopAfterFillingStacks      = false;
-		//public boolean enableFavorites             = true;
+	public boolean enableDumpFeature           = true;
+	public boolean enableQuickStackFeature     = true;
+	public boolean ignoreHotbar = true;
+	@ConfigEntry.BoundedDiscrete(min = 0,max = 30)
+	public int     searchRadius                = 5;
+	@ConfigEntry.BoundedDiscrete(min = 0,max = 100)
+	public int     maxContainersPerDump        = 50;
+	public boolean enableQuickStackOutputInfo  = true;
+	public boolean stopAfterFillingStacks      = false;
+	//public boolean enableFavorites             = true;
 
+	public PacketByteBuf writeConfig() {
+		var buf = new PacketByteBuf(Unpooled.buffer());
+
+		buf.writeBoolean(ignoreHotbar);
+		buf.writeInt(searchRadius);
+		buf.writeInt(maxContainersPerDump);
+		buf.writeBoolean(enableQuickStackOutputInfo);
+		buf.writeBoolean(stopAfterFillingStacks);
+
+		return buf;
+	}
+
+	public static QSConfig readConfig(PacketByteBuf buf) {
+		var config = new QSConfig();
+
+		config.ignoreHotbar = buf.readBoolean();
+		config.searchRadius = buf.readInt();
+		config.maxContainersPerDump = buf.readInt();
+		config.enableQuickStackOutputInfo = buf.readBoolean();
+		config.stopAfterFillingStacks = buf.readBoolean();
+
+		return config;
+	}
 }


### PR DESCRIPTION
Fixes #5 

Adds some utilities to allow the client to send its config to the server using packetbytebufs, and for the server to utilise these instead of its own config. This means allows users to configure their own experience.